### PR TITLE
Defaults standardization

### DIFF
--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -58,7 +58,7 @@ Base.@kwdef mutable struct InputsStruct
     ##### These are the exact /GhpGhx POST names from the API #####
     # Parameters
     heat_pump_configuration::String  = "WSHP"  # "WSHP" or "WWHP"
-    borehole_depth_ft::Float64 = 400.0
+    borehole_depth_ft::Float64 = 443.0 # old value = 400, ResStock = 152m, ComStock and URBANopt = 135m = 443 ft
     ghx_header_depth_ft::Float64 = 6.6    # old value = 4.0 # ResStock, ComStock, and URBANopt value is 2m = 6.56168 ft
     borehole_spacing_ft::Float64 = 20.0
     borehole_diameter_inch::Float64 = 6.0 # old value = 5 inch, ResStock, ComStock, and URBANopt value is 6 inch
@@ -70,7 +70,7 @@ Base.@kwdef mutable struct InputsStruct
     ground_thermal_conductivity_btu_per_hr_ft_f::Float64 = NaN  # Default depends on climate zone
     ground_mass_density_lb_per_ft3::Float64 = 162.3
     ground_specific_heat_btu_per_lb_f::Float64 = 0.211
-    grout_thermal_conductivity_btu_per_hr_ft_f::Float64 = 1.0
+    grout_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.75 # old value = 1.0, ResStock, ComStock, URBANopt value = 1.3 W/m-K = 0.75 BTU/ft-F
     ghx_fluid_specific_heat_btu_per_lb_f::Float64 = 1.0
     ghx_fluid_mass_density_lb_per_ft3::Float64 = 62.4
     ghx_fluid_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.34

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -59,14 +59,14 @@ Base.@kwdef mutable struct InputsStruct
     # Parameters
     heat_pump_configuration::String  = "WSHP"  # "WSHP" or "WWHP"
     borehole_depth_ft::Float64 = 400.0
-    ghx_header_depth_ft::Float64 = 4.0
+    ghx_header_depth_ft::Float64 = 6.6    # old value = 4.0 # ResStock, ComStock, and URBANopt value is 2m = 6.56168 ft
     borehole_spacing_ft::Float64 = 20.0
-    borehole_diameter_inch::Float64 = 5.0
+    borehole_diameter_inch::Float64 = 6.0 # old value = 5 inch, ResStock, ComStock, and URBANopt value is 6 inch
     borehole_spacing_type::String  = "rectangular"  # "rectangular" or "hexagonal"
     ghx_pipe_outer_diameter_inch::Float64 = 1.66
     ghx_pipe_wall_thickness_inch::Float64 = 0.16
-    ghx_pipe_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.25
-    ghx_shank_space_inch::Float64 = 2.5
+    ghx_pipe_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.23 # Old value = 0.25 = 0.43 W/m-K. ReStock, ComStock and URBANopt value is 0.4 W/m-K which is 0.23127039296 BTU/ft-F
+    ghx_shank_space_inch::Float64 = 1.27 # old value = 2.5, ResStock = 0.0246m = 0.97 inch, ComStock & URBANopt = 0.0323m = 1.27 inch. Goes with ComStock & URBANopt value
     ground_thermal_conductivity_btu_per_hr_ft_f::Float64 = NaN  # Default depends on climate zone
     ground_mass_density_lb_per_ft3::Float64 = 162.3
     ground_specific_heat_btu_per_lb_f::Float64 = 0.211

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -58,19 +58,19 @@ Base.@kwdef mutable struct InputsStruct
     ##### These are the exact /GhpGhx POST names from the API #####
     # Parameters
     heat_pump_configuration::String  = "WSHP"  # "WSHP" or "WWHP"
-    borehole_depth_ft::Float64 = 443.0 # old value = 400, ResStock = 152m, ComStock and URBANopt = 135m = 443 ft
-    ghx_header_depth_ft::Float64 = 6.6    # old value = 4.0 # ResStock, ComStock, and URBANopt value is 2m = 6.56168 ft
+    borehole_depth_ft::Float64 = 443.0 # ResStock = 152m, ComStock and URBANopt = 135m = 443 ft
+    ghx_header_depth_ft::Float64 = 6.6    # ResStock, ComStock, and URBANopt value is 2m = 6.56168 ft
     borehole_spacing_ft::Float64 = 20.0
-    borehole_diameter_inch::Float64 = 6.0 # old value = 5 inch, ResStock, ComStock, and URBANopt value is 6 inch
+    borehole_diameter_inch::Float64 = 6.0 # ResStock, ComStock, and URBANopt value is 6 inch
     borehole_spacing_type::String  = "rectangular"  # "rectangular" or "hexagonal"
     ghx_pipe_outer_diameter_inch::Float64 = 1.66
     ghx_pipe_wall_thickness_inch::Float64 = 0.16
-    ghx_pipe_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.23 # Old value = 0.25 = 0.43 W/m-K. ReStock, ComStock and URBANopt value is 0.4 W/m-K which is 0.23127039296 BTU/ft-F
-    ghx_shank_space_inch::Float64 = 1.27 # old value = 2.5, ResStock = 0.0246m = 0.97 inch, ComStock & URBANopt = 0.0323m = 1.27 inch. Goes with ComStock & URBANopt value
+    ghx_pipe_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.23 # ReStock, ComStock and URBANopt value is 0.4 W/m-K which is 0.23127039296 BTU/ft-F
+    ghx_shank_space_inch::Float64 = 1.27 # ResStock = 0.0246m = 0.97 inch, ComStock & URBANopt = 0.0323m = 1.27 inch. Goes with ComStock & URBANopt value
     ground_thermal_conductivity_btu_per_hr_ft_f::Float64 = NaN  # Default depends on climate zone
     ground_mass_density_lb_per_ft3::Float64 = 162.3
     ground_specific_heat_btu_per_lb_f::Float64 = 0.211
-    grout_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.75 # old value = 1.0, ResStock, ComStock, URBANopt value = 1.3 W/m-K = 0.75 BTU/ft-F
+    grout_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.75 # ResStock, ComStock, URBANopt value = 1.3 W/m-K = 0.75 BTU/ft-F
     ghx_fluid_specific_heat_btu_per_lb_f::Float64 = 1.0
     ghx_fluid_mass_density_lb_per_ft3::Float64 = 62.4
     ghx_fluid_thermal_conductivity_btu_per_hr_ft_f::Float64 = 0.34


### PR DESCRIPTION
# About
This PR updates REopt's default GHP/GHX parameters to match with defaults from ResStock, ComStock and URBANopt as part of an effort to standardize defaults across NREL models.

# Updated Defaults
| Default | Defaults values changed | Notes |
| --- | --- | --- |
| `borehole_depth_ft ` | 400.0 ft => 443.0 ft | ResStock = 152m, ComStock, URBANopt = 135m = 443 ft. Goes with ComStock & URBANopt |
| `ghx_header_depth_ft ` | 4.0 ft => 6.6 ft | ResStock, ComStock, URBANopt = 2m = 6.56168 ft |
| `borehole_diameter_inch ` | 5.0 in => 6.0 in | ResStock, ComStock, and URBANopt = 6 in|
| `ghx_pipe_thermal_conductivity_btu_per_hr_ft_f ` | 0.25 => 0.23 | ComStock & URBANopt = 0.4 W/m-K = is 0.23127039296 BTU/ft-F |
| `ghx_shank_space_inch` | 2.5 in => 1.27 in | ResStock = 0.0246m = 0.97 in, ComStock & URBANopt = 0.0323m = 1.27 in. Goes with ComStock & URBANopt |
| `grout_thermal_conductivity_btu_per_hr_ft_f ` | 1.0 => 0.75 | ResStock, ComStock, URBANopt = 1.3 W/m-K = 0.75 BTU/ft-F|

# Test Case
GHP module was run for a site in Alaska before and after the changes:
| Output | Before the changes | After the changes |
| --- | --- | --- |
| `heat_pump_configuration ` | "WSHP" | "WSHP" |
| `peak_heating_heatpump_thermal_ton ` | 121.808 | 121.808|
| `number_of_boreholes ` | 52 | 64 |
| `length_boreholes_ft ` | 393.2 | 396.2 |
| `yearly_total_electric_consumption_kwh ` | 98113.6 | 95848.6 | 